### PR TITLE
Expand fix from e5de60d9fb to query variable

### DIFF
--- a/lib/acts_as_ferret/ferret_find_methods.rb
+++ b/lib/acts_as_ferret/ferret_find_methods.rb
@@ -112,7 +112,8 @@ module ActsAsFerret
       # Force q to be encoded as UTF-8 to avoid barfing when unicode passed in.
       # Was not an issue pre ruby 1.9.x force_encoding method is only available in ruby 1.9.x
       q_to_s = q.to_s.respond_to?('force_encoding') ? q.to_s.force_encoding('UTF-8') : q
-      logger.debug "query: #{query}\n-->#{q_to_s}"
+      query_to_s = query.to_s.respond_to?('force_encoding') ? query.to_s.force_encoding('UTF-8') : query
+      logger.debug "query: #{query_to_s}\n-->#{q_to_s}"
       s = searcher
       total_hits = s.search_each(q, options) do |hit, score|
         doc = s[hit]


### PR DESCRIPTION
The fix for ruby 1.9+ needs to apply to "query", too. Not only "q".
